### PR TITLE
Disable directory listings for Apache webserver.

### DIFF
--- a/eda/docker_run.sh
+++ b/eda/docker_run.sh
@@ -43,6 +43,7 @@ then
         a2enmod proxy_balancer
         a2enmod proxy_connect
         a2enmod proxy_html
+        a2dismod -f autoindex
 
 
         cd /eda/eda_app/


### PR DESCRIPTION
Do not allow users inspect Apache directory listings with URLs like http://localhost/en/assets